### PR TITLE
Use Version variable for --version default cli

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -21,7 +21,7 @@ var (
 func main() {
 	ui := &cli.BasicUi{Writer: os.Stdout}
 
-	c := cli.NewCLI("gitlab-ci-helper", "0.0.1-DEV")
+	c := cli.NewCLI("gitlab-ci-helper", Version)
 	c.Args = os.Args[1:]
 
 	c.Commands = map[string]cli.CommandFactory{


### PR DESCRIPTION
To have same output for `version` and `--version` options:

Before:
```
$ build/linux-amd64-gitlab-ci-helper version && build/linux-amd64-gitlab-ci-helper --version
0.0.3-Dev
0.0.1-DEV
```

After:
```
$ build/linux-amd64-gitlab-ci-helper version && build/linux-amd64-gitlab-ci-helper --version
0.0.3-Dev
0.0.3-Dev
```