### PR TITLE
fix(deps): use go-gitlab-client v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 
 go: [1.9]
 
+# this might be useful when working on a fork for example
+go_import_path: github.com/rande/gitlab-ci-helper
+
 sudo: required
 
 services :

--- a/commands/project_build_artifacts.go
+++ b/commands/project_build_artifacts.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/cli"
-	gitlab "github.com/plouc/go-gitlab-client"
+	gitlab "gopkg.in/plouc/go-gitlab-client.v1"
 	helper "github.com/rande/gitlab-ci-helper"
 )
 

--- a/commands/project_builds_list.go
+++ b/commands/project_builds_list.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/cli"
-	gitlab "github.com/plouc/go-gitlab-client"
+	gitlab "gopkg.in/plouc/go-gitlab-client.v1"
 	helper "github.com/rande/gitlab-ci-helper"
 )
 

--- a/commands/project_list.go
+++ b/commands/project_list.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/cli"
-	gitlab "github.com/plouc/go-gitlab-client"
+	gitlab "gopkg.in/plouc/go-gitlab-client.v1"
 	helper "github.com/rande/gitlab-ci-helper"
 )
 

--- a/commands/s3_archive.go
+++ b/commands/s3_archive.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/mitchellh/cli"
-	gitlab "github.com/plouc/go-gitlab-client"
+	gitlab "gopkg.in/plouc/go-gitlab-client.v1"
 	helper "github.com/rande/gitlab-ci-helper"
 )
 

--- a/commands/s3_extract.go
+++ b/commands/s3_extract.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/cli"
-	gitlab "github.com/plouc/go-gitlab-client"
+	gitlab "gopkg.in/plouc/go-gitlab-client.v1"
 	helper "github.com/rande/gitlab-ci-helper"
 
 	"io"

--- a/helper.go
+++ b/helper.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
-	gitlab "github.com/plouc/go-gitlab-client"
+	gitlab "gopkg.in/plouc/go-gitlab-client.v1"
 )
 
 type Paths []string

--- a/integrations/flowdock/ci_flowdock_ci_status.go
+++ b/integrations/flowdock/ci_flowdock_ci_status.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/cli"
-	gitlab "github.com/plouc/go-gitlab-client"
+	gitlab "gopkg.in/plouc/go-gitlab-client.v1"
 	helper "github.com/rande/gitlab-ci-helper"
 )
 


### PR DESCRIPTION
See https://github.com/rande/gitlab-ci-helper/issues/21.

Introducing something like `dep` or `glide` requires extra tooling, I've just used [gopkg.in](http://labix.org/gopkg.in) to force usage of `go-gitlab-client` v1 as it's not BC due to changes on the GitLab API itself too.